### PR TITLE
Rust のコードを最新にした

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ FORCE:
 
 .PHONY: rust
 rust:
+	cd etc && cargo update
 	cargo check --manifest-path=etc/Cargo.toml --target-dir=var/rust-target
+	cargo fix --allow-dirty --allow-staged --manifest-path=etc/Cargo.toml --target-dir=var/rust-target
+	cargo clippy --all --manifest-path=etc/Cargo.toml --target-dir=var/rust-target
 	cd etc && cargo fmt
 	cargo test --manifest-path=etc/Cargo.toml --target-dir=var/rust-target

--- a/etc/Cargo.lock
+++ b/etc/Cargo.lock
@@ -2,16 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.6.9"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "idna"
@@ -20,17 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
-version = "0.2.43"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -40,13 +30,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -55,35 +40,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "1.0.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "smallvec"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ucd-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -96,8 +86,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"
@@ -111,39 +104,32 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xsvutils"
 version = "0.1.0"
 dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
-"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
-"checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
+"checksum regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b2f0808e7d7e4fb1cb07feb6ff2f4bc827938f24f8c2e6a3beb7370af544bdd"
+"checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"

--- a/etc/Cargo.toml
+++ b/etc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "xsvutils"
 version = "0.1.0"
+edition = "2018"
 
 [[bin]]
 name = "xsvutils-rs"
@@ -8,6 +9,9 @@ path = "../src/main.rs"
 
 [dependencies]
 regex = "1"
-lazy_static = "1.2"
+lazy_static = "1"
 memchr = "2"
-url = "1.7"
+url = "1"
+
+[profile.release]
+lto = true

--- a/etc/build-makefile.sh
+++ b/etc/build-makefile.sh
@@ -203,7 +203,7 @@ target/xsvutils-rs: cargo-build
 .PHONY: cargo-build
 cargo-build:
 	\$(RUSTUP) target add $target
-	\$(CARGO) build --quiet --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target --target $target
+	\$(CARGO) build --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target --target $target
 
 EOF
 
@@ -215,7 +215,7 @@ target/xsvutils-rs: cargo-build
 
 .PHONY: cargo-build
 cargo-build:
-	\$(CARGO) build --quiet --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target
+	\$(CARGO) build --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target
 
 EOF
 

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -1,11 +1,10 @@
+use crate::util;
+use lazy_static::lazy_static;
+use memchr::memchr;
+use regex::Regex;
 use std::io;
 use std::io::BufRead;
 use std::io::Write;
-
-use memchr::memchr;
-use regex::Regex;
-
-use crate::util;
 
 pub struct CutCommand;
 impl crate::command::Command for CutCommand {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,9 @@
-use std::io;
-use std::io::BufWriter;
-
-#[macro_use]
-extern crate lazy_static;
-extern crate memchr;
-extern crate regex;
-extern crate url;
-
-use std::env;
-
 #[macro_use]
 mod util;
+
+use std::env;
+use std::io;
+use std::io::BufWriter;
 mod command;
 mod cut;
 mod uriparams;

--- a/src/uriparams.rs
+++ b/src/uriparams.rs
@@ -1,13 +1,12 @@
+use crate::util;
+use lazy_static::lazy_static;
+use memchr::memchr;
+use regex::Regex;
 use std::io;
 use std::io::BufRead;
 use std::io::Write;
 use std::iter;
-
-use memchr::memchr;
-use regex::Regex;
 use url;
-
-use crate::util;
 
 pub struct UriParamsCommand;
 impl crate::command::Command for UriParamsCommand {
@@ -251,14 +250,14 @@ fn escape(str: &str) -> String {
         match ch {
             '\\' => buff.push_str("\\\\"),
             ';' => buff.push_str("\\x3B"),
-            '\x00'...'\x1F' | '\x7F' => write!(buff, "\\x{:02X}", ch as u8).unwrap(),
+            '\x00'..='\x1F' | '\x7F' => write!(buff, "\\x{:02X}", ch as u8).unwrap(),
             _ => buff.push(ch),
         }
     }
     return buff;
 }
 
-fn parse(url: &[u8]) -> url::form_urlencoded::Parse {
+fn parse(url: &[u8]) -> url::form_urlencoded::Parse<'_> {
     let url = match memchr(b'?', url) {
         Some(ix) => &url[ix + 1..],
         None => url,
@@ -355,7 +354,8 @@ mod tests {
         let actual = run_uriparams(
             &["--col", "querystring", "--names", "q,r", "--multi-value-b"],
             input,
-        ).unwrap();
+        )
+        .unwrap();
         for (exp, act) in exptected.lines().zip(actual.lines()) {
             assert_eq!(exp, act);
         }
@@ -370,7 +370,8 @@ mod tests {
         let actual = run_uriparams(
             &["--col", "querystring", "--name-list", "--multi-value-b"],
             input,
-        ).unwrap();
+        )
+        .unwrap();
         for (exp, act) in exptected.lines().zip(actual.lines()) {
             assert_eq!(exp, act);
         }


### PR DESCRIPTION
## 変更内容

* 構文を Rust2018 に対応した
* 依存ライブラリのバージョンアップを行った
* ビルドフラグとして Link Time Optimization (LTO) を有効にした

## LTOの効果

before
```
$ ll target/xsvutils-rs
.rwxrwxr-x  postgres  postgres  2.7 MB  Wed Jul  3 10:42:14 2019    xsvutils-rs*
```
after:
```
$ ll target/xsvutils-rs
.rwxrwxr-x  postgres  postgres  1.9 MB  Wed Jul  3 10:40:06 2019    xsvutils-rs*
```
