### PR TITLE
-v12 --install に失敗するバグの修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ To see compatibility information, `xsvutils help compatibility`.
 
 ## v12 -> v13 (Unreleased)
 
+-v12 --install のバグを解決し -v13 --install はできるようにした。
+-v12 --install 自体は解決できない。
+
+~/.xsvutils/repos-build の中のソースを手動修正してある場合でも強制的に上書きして
+-vXX --install を実行できるようにした。
+
+
 ## v11 -> v12 (2019/07/17)
 
 以下のサブコマンドが追加された。
@@ -19,6 +26,9 @@ insconst に依存していた sort コマンドも高速化となった。
 CSVからTSVへの変換がGo言語からRustでの実装に置き換わり、CSVファイルの読み込みが高速化された。
 
 --install-rt はJavaが必要となるまでは実行しなくてもいいように変更した。
+
+[追記]
+-v12 --install にはバグがありビルドできない。 -v13 --install を使うこと。
 
 
 ## v10 -> v11 (2019/06/29)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 build: var/makefile
-	git submodule update --init
+	# ここを修正する場合は src/install.sh の修正も必要
+	# それよりは etc/build-makefile.sh の修正のほうが望ましい
 	make --question -f var/makefile build || make -f var/makefile build
 
 gobuild: var/makefile

--- a/etc/build-makefile.sh
+++ b/etc/build-makefile.sh
@@ -207,9 +207,12 @@ target/mcut: build-mcut
 	cp -p ext/mtools/target/$target/release/mcut target/mcut
 
 .PHONY: build-mcut
-build-mcut:
+build-mcut: git-submodule
 	cd ext/mtools && \$(RUSTUP) target add $target
 	cd ext/mtools && \$(CARGO) build --release --target $target
+
+git-submodule:
+	git submodule update --init
 
 EOF
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -72,7 +72,7 @@ if [ ! -e $BUILD_DIR/var/xsvutils$version ]; then
     (
         cd $BUILD_DIR
         git fetch --prune
-        git checkout -q $GIT_HASH || exit $?
+        git checkout -f -q $GIT_HASH || exit $?
 
         make var/makefile || exit $?
 


### PR DESCRIPTION
-v12 --install はもう直せないので、
-v13 --install が大丈夫なようにするための修正です。
