### PR TITLE
Specify CP932 instead of Shift-JIS

### DIFF
--- a/src/format-wrapper.pl
+++ b/src/format-wrapper.pl
@@ -192,7 +192,7 @@ sub guess_charencoding {
     }
     $utf8bom = '0';
     if (!$utf8_flag && $sjis_flag) {
-        return ($head_buf, "SHIFT-JIS", $utf8bom);
+        return ($head_buf, "cp932", $utf8bom);
     } else {
         if ($len >= 3) {
             if (substr($head_buf, 0, 3) eq "\xEF\xBB\xBF") {


### PR DESCRIPTION
iconvの引数に `SHIFT-JIS` を指定していた箇所で `cp932` を指定するようにした。

---
文字コード変換がファイルの最後まで実行されるようになった。
テストに用いたCSVは [住所データCSV【住所.jp】](http://jusyo.jp/csv/new.php) を利用した。

before:
```
$ time ./xsvutils ../item_files/zenkoku.csv >/dev/null
iconv: illegal input sequence at position 5526156

real    0m0.275s
user    0m0.241s
sys     0m0.030s
```

after:
```
$ time ./xsvutils ../item_files/zenkoku.csv >/dev/null

real    0m0.521s
user    0m0.479s
sys     0m0.041s
```