### PR TITLE
remove git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/mtools"]
-	path = ext/mtools
-	url = https://github.com/ng3rdstmadgke/mtools.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ To see compatibility information, `xsvutils help compatibility`.
 ~/.xsvutils/repos-build の中のソースを手動修正してある場合でも強制的に上書きして
 -vXX --install を実行できるようにした。
 
+git clone 以外の方法でソースをダウンロードしてきた場合にビルドできない問題を解消したつもり。
+
 
 ## v11 -> v12 (2019/07/17)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
+# ここを修正する場合は src/install.sh の修正も必要
+# それよりは etc/build-makefile.sh の修正のほうが望ましい
 build: var/makefile
-	# ここを修正する場合は src/install.sh の修正も必要
-	# それよりは etc/build-makefile.sh の修正のほうが望ましい
 	make --question -f var/makefile build || make -f var/makefile build
 
 gobuild: var/makefile

--- a/etc/build-makefile.sh
+++ b/etc/build-makefile.sh
@@ -193,6 +193,8 @@ EOF
 
 if [ "$uname" = "Linux" ]; then
 
+mtools_hash=488b652e5c530c1f100e7f431f37ea78fe23913b
+
 cargo_target=x86_64-unknown-linux-musl
 cat <<EOF
 target/xsvutils-rs: cargo-build
@@ -203,16 +205,20 @@ cargo-build:
 	\$(RUSTUP) target add $cargo_target
 	\$(CARGO) build --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target --target $cargo_target
 
-target/mcut: build-mcut
-	cp -p ext/mtools/target/$cargo_target/release/mcut target/mcut
+target/mcut: var/mtools/target/$cargo_target/release/mcut
+	cp -p var/mtools/target/$cargo_target/release/mcut target/mcut
 
-.PHONY: build-mcut
-build-mcut: git-submodule
-	cd ext/mtools && \$(RUSTUP) target add $cargo_target
-	cd ext/mtools && \$(CARGO) build --release --target $cargo_target
+var/mtools/target/$cargo_target/release/mcut: var/mtools/hash-$mtools_hash
+	cd var/mtools && \$(RUSTUP) target add $cargo_target
+	cd var/mtools && \$(CARGO) build --release --target $cargo_target
 
-git-submodule:
-	git submodule update --init
+var/mtools/hash-$mtools_hash: var/mtools/.gitignore
+	rm -f var/mtools/hash-*
+	touch var/mtools/hash-$mtools_hash
+
+var/mtools/.gitignore:
+	git clone https://github.com/ng3rdstmadgke/mtools.git var/mtools
+	cd var/mtools && git checkout $mtools_hash
 
 EOF
 

--- a/etc/build-makefile.sh
+++ b/etc/build-makefile.sh
@@ -224,6 +224,10 @@ EOF
 
 else
 
+    # TODO このelse節(Linux以外)のコードは以下の2チケットで修正漏れ
+    # https://github.com/xsvutils/xsvutils/pull/12
+    # https://github.com/xsvutils/xsvutils/pull/15
+
 cat <<EOF
 target/xsvutils-rs: cargo-build
 	cp -p var/rust-target/release/xsvutils-rs target/xsvutils-rs

--- a/etc/build-makefile.sh
+++ b/etc/build-makefile.sh
@@ -193,23 +193,23 @@ EOF
 
 if [ "$uname" = "Linux" ]; then
 
-target=x86_64-unknown-linux-musl
+cargo_target=x86_64-unknown-linux-musl
 cat <<EOF
 target/xsvutils-rs: cargo-build
-	cp -p var/rust-target/$target/release/xsvutils-rs target/xsvutils-rs
+	cp -p var/rust-target/$cargo_target/release/xsvutils-rs target/xsvutils-rs
 
 .PHONY: cargo-build
 cargo-build:
-	\$(RUSTUP) target add $target
-	\$(CARGO) build --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target --target $target
+	\$(RUSTUP) target add $cargo_target
+	\$(CARGO) build --release --manifest-path=etc/Cargo.toml --target-dir=var/rust-target --target $cargo_target
 
 target/mcut: build-mcut
-	cp -p ext/mtools/target/$target/release/mcut target/mcut
+	cp -p ext/mtools/target/$cargo_target/release/mcut target/mcut
 
 .PHONY: build-mcut
 build-mcut: git-submodule
-	cd ext/mtools && \$(RUSTUP) target add $target
-	cd ext/mtools && \$(CARGO) build --release --target $target
+	cd ext/mtools && \$(RUSTUP) target add $cargo_target
+	cd ext/mtools && \$(CARGO) build --release --target $cargo_target
 
 git-submodule:
 	git submodule update --init


### PR DESCRIPTION
mtools のダウンロードに git submodule を使っていたために
xsvutils自体のソースをgit以外の手段でダウンロードした場合にビルドできない問題があった。
git submodule のかわりにビルド時に git clone するように変更することで解消する。
