### PR TITLE
remove perl Data::Dumper

### DIFF
--- a/src/main.pl
+++ b/src/main.pl
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Data::Dumper;
+#use Data::Dumper;
 
 use POSIX qw/mkfifo/;
 

--- a/src/subcmd_mcut.pm
+++ b/src/subcmd_mcut.pm
@@ -2,7 +2,7 @@ package subcmd_mcut;
 
 use strict;
 use warnings;
-use Data::Dumper;
+#use Data::Dumper;
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
Amazon Linuxインストール直後はperlの `Data::Dumper` というパッケージがないため実行できなかった。このパッケージは使っていないので、依存を解消する。
